### PR TITLE
4 bits and storage reverse

### DIFF
--- a/Source/vmde/detect.c
+++ b/Source/vmde/detect.c
@@ -547,7 +547,8 @@ BYTE GetHypervisorType(
 	}
 
 	// Parallels VMM ids.
-	if (_strcmpi_a(HvProductName, "prl hyperv") == 0) {
+	// if (_strcmpi_a(HvProductName, "prl hyperv") == 0) {
+	if (_strcmpi_a(HvProductName, " lrpepyh  vr") == 0) {
 		DebugLog(TEXT("GetHypervisorType, Parallels"));
 		return 3;
 	}


### PR DESCRIPTION
after `memcpy(HvProductName, CPUInfo + 1, 12)`,
`CPUInfo` is " lrpepyh  vr", not "prl hyperv"
